### PR TITLE
ADD: dequeue animal *with* preference (and tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ class AnimalShelter():
 - [x] enq one
 - [x] enq many
 - [x] deq one (no pref)
-- [ ] deq one (with pref)
+- [x] deq one (with pref)
 - [x] deq until empty
 
 ## STRETCH

--- a/challenges/fifo_animal_shelter/Pipfile
+++ b/challenges/fifo_animal_shelter/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pytest = "*"
+
+[requires]
+python_version = "3.7"

--- a/challenges/fifo_animal_shelter/fifo_animal_shelter.py
+++ b/challenges/fifo_animal_shelter/fifo_animal_shelter.py
@@ -5,7 +5,7 @@ sys.path.insert(0, parentdir+'\\..\\data-structures\\stacks_and_queues')
 p = parentdir+'\\..\\data-structures\\linked_list'
 sys.path.insert(0,p)
 sys.path.insert(0,p)
-from stacks_and_queues import Queue
+from stacks_and_queues import Queue, Stack
 from enum import IntEnum
 import json
 
@@ -72,9 +72,52 @@ class AnimalShelter():
 
     def dequeue(self, pref : AnimalType=None) -> Animal:
         # grab animal that has been in queue the longest, optionally provide parameter
-        b, val = self.q.peek()
-        if not b:
-            return None
 
-        if self.q.dequeue(val):
-            return Animal.Factory(val)
+        # No Pref First
+        if pref == None:
+            b, val = self.q.peek()
+            if not b:
+                return None
+
+            if self.q.dequeue(val):
+                return Animal.Factory(val)
+        else:
+            stack = Stack()
+
+            # Find the Animal we Want (deq, push to stack)
+            found = False
+            b, val = self.q.peek()
+            while b:
+                animal = Animal.Factory(val)
+                if animal.animaltype == pref:
+                    found = True
+                    break
+                stack.push(val)
+                self.q.dequeue(val)
+
+                b, val = self.q.peek()
+
+            if found:
+
+                # Pop off stack and enqueue back to queue
+                # record the current count, as we need to cycle the enq (back of line) to the front
+                c = self.q.count()
+                b, val = stack.peek()
+                while b:
+                    val = stack.pop()
+                    self.q.enqueue(val)
+
+                    b, val = stack.peek()
+
+                # cycle the back of the list to the front
+                diff = self.q.count() - c
+                for x in range(diff):
+                    val = self.q.peek()
+                    self.q.dequeue(val)
+                    self.q.enqueue(val)
+
+                return animal
+            else:
+                return None
+
+

--- a/challenges/fifo_animal_shelter/test_fifo_animal_shelter.py
+++ b/challenges/fifo_animal_shelter/test_fifo_animal_shelter.py
@@ -39,7 +39,7 @@ def test_shelter_enq_deq():
     assert actual == expected
 
 
-def test_shelter_enq_lots():
+def helper_shelter_enq10():
     shelter = AnimalShelter()
 
     # Inc 10 (ALTERNATING)
@@ -54,6 +54,13 @@ def test_shelter_enq_lots():
     shelter.enqueue(Animal(AnimalType.CAT))
     shelter.enqueue(Animal(AnimalType.DOG))
 
+    return shelter
+
+
+def test_shelter_enq_lots():
+
+    shelter = helper_shelter_enq10()
+
     # Deq 10
     for x in range(10):
         a = shelter.dequeue()
@@ -66,10 +73,42 @@ def test_shelter_enq_lots():
 
         assert actual == expected
 
-def test_shelter_deq_empty():
-    # @TODO
-    pass
 
-def test_shelter_deq_prev():
-    # @TODO
-    pass
+def test_shelter_deq_empty():
+    shelter = helper_shelter_enq10()
+
+    # Deq 10
+    for x in range(10):
+        shelter.dequeue()
+
+    # Deq EMPTY
+    expected = None
+    actual = shelter.dequeue()
+    assert expected == actual
+
+def test_shelter_deq_pref_found():
+    shelter = AnimalShelter()
+
+    # Inc 10 (ALTERNATING)
+    shelter.enqueue(Animal(AnimalType.CAT))
+    shelter.enqueue(Animal(AnimalType.CAT))
+    shelter.enqueue(Animal(AnimalType.CAT))
+    shelter.enqueue(Animal(AnimalType.DOG))
+    shelter.enqueue(Animal(AnimalType.DOG))
+
+    animal = shelter.dequeue(AnimalType.DOG)
+    actual = animal.serialize()
+    expected = '{"animaltype": 2}'
+    assert actual == expected
+
+def test_shelter_deq_pref_notfound():
+    shelter = AnimalShelter()
+
+    # Inc 10 (ALTERNATING)
+    shelter.enqueue(Animal(AnimalType.CAT))
+    shelter.enqueue(Animal(AnimalType.CAT))
+    shelter.enqueue(Animal(AnimalType.CAT))
+
+    actual = shelter.dequeue(AnimalType.DOG)
+    expected = None
+    assert actual == expected


### PR DESCRIPTION
## Challenge
FIFO Animal Shelter: create a class called AnimalShelter which holds only dogs/cats. The shelter operates as first-in / first-out
## API
```

class AnimalType(IntEnum):

class Animal(object):
    def __init__(self, animaltype : AnimalType):
        # create internal data structs
    def serialize(self):
        # return json for obj
    def Factory(jsonstr : str): # -> Animal
        # create Animal class Dog|Cat for Json

class Cat(Animal):
    def __init__(self):
        # create internal data structs

class Dog(Animal):
    def __init__(self):
        # create internal data structs

class AnimalShelter():
    def __init__(self):
        # create internal data structs
    def enqueue(self, animal : Animal):
        # add animal to shelter
    def dequeue(self, pref : AnimalType=None) -> Animal:
        # grab animal that has been in queue the longest, optionally provide parameter

```
## TESTS
- [x] class existence
- [x] enq one
- [x] enq many
- [x] deq one (no pref)
- [x] deq one (with pref)
- [x] deq until empty

## STRETCH
- [ ] deq oldest
```
## Whiteboard
![alt_text](https://raw.githubusercontent.com/marvincolgin/data-structures-and-algorithms/SOMEUUID/challenges/fifo_animal_shelter/assets/whiteboard.jpg)
